### PR TITLE
fix font-size for firefox different lang

### DIFF
--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -178,3 +178,7 @@ html.dark .DocSearch {
   --docsearch-footer-shadow: inset 0 1px 0 0 rgba(73, 76, 106, 0.5),
     0 -4px 8px 0 rgba(0, 0, 0, 0.2);
 }
+
+html {
+  font-size: 16px;
+}


### PR DESCRIPTION
在 firefox 上設定不同的 lang 會影響 html 這層的 font-size 
目前想到的解決方式有兩種

1. 這個 PR 的方式
2. 是作者發文時的 lang 都要設定成一樣 

<img width="1920" alt="圖片" src="https://user-images.githubusercontent.com/7929959/200536998-b06286fb-961f-4553-af6a-fbf51ea127f4.png">
<img width="1920" alt="圖片" src="https://user-images.githubusercontent.com/7929959/200537052-bd258239-efba-4f54-9299-232ec6a17015.png">


[reference](https://discourse.mozilla.org/t/adding-lang-attribute-break-default-font-size/26756)